### PR TITLE
fix: optional walkthroughable copilot prop

### DIFF
--- a/src/hocs/walkthroughable.tsx
+++ b/src/hocs/walkthroughable.tsx
@@ -1,12 +1,14 @@
 import React, { type FunctionComponent } from "react";
 import { type NativeMethods } from "react-native/types";
 
-type PropsWithCopilot<P> = P & {
-  copilot: {
+interface WithCopilot {
+  copilot?: {
     ref?: React.RefObject<NativeMethods>;
     onLayout?: () => void;
   };
-};
+}
+
+type PropsWithCopilot<P> = P & WithCopilot;
 
 export function walkthroughable<P = any>(
   WrappedComponent: React.ComponentType<P>

--- a/src/hocs/walkthroughable.tsx
+++ b/src/hocs/walkthroughable.tsx
@@ -1,4 +1,4 @@
-import React, { type FunctionComponent } from "react";
+import React from "react";
 import { type NativeMethods } from "react-native/types";
 
 interface WithCopilot {
@@ -13,10 +13,9 @@ type PropsWithCopilot<P> = P & WithCopilot;
 export function walkthroughable<P = any>(
   WrappedComponent: React.ComponentType<P>
 ) {
-  const Component: FunctionComponent<PropsWithCopilot<P>> = ({
-    copilot,
-    ...props
-  }) => <WrappedComponent {...(copilot as any)} {...props} />;
+  const Component = ({ copilot, ...props }: PropsWithCopilot<P>) => {
+    return <WrappedComponent {...(copilot as any)} {...props} />;
+  };
 
   Component.displayName = "Walkthroughable";
 


### PR DESCRIPTION
# Overview
This PR makes the `copilot` prop that is attached to a `walkthroughable` component optional to prevent type-errors when rendering the component.